### PR TITLE
Use @compat for new Dict syntax

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 PyPlot
+Compat

--- a/src/JuliaReport.jl
+++ b/src/JuliaReport.jl
@@ -1,4 +1,5 @@
 module JuliaReport
+using Compat
 using PyCall
 using PyPlot
 @pyimport pweave #Output formatting uses Pweave
@@ -17,7 +18,7 @@ type Report
 end
 
 
-const report = Report("", false, "", "",  {}, "", "")
+const report = Report("", false, "", "",  Any[], "", "")
 
 function listformats()
   pweave.listformats()
@@ -149,6 +150,8 @@ function savefigs(chunk)
 end
 
 export weave
+
+typealias StrD Dict{ASCIIString,Any}
 
 include("config.jl")
 include("readers.jl")

--- a/src/config.jl
+++ b/src/config.jl
@@ -1,26 +1,26 @@
-const rcParams = {"figdir"=> "figures",
-                  "usematplotlib"=> true,
-                  "storeresults"=> false,
-                  "cachedir"=> "cache",
-                  "chunk"=>
-                  {"defaultoptions"=>
-                   {
-                    "echo"=> true,
-                    "results"=> "verbatim",
-                    "fig"=> true,
-                    "include"=> true,
-                    "evaluate"=> true,
-                    "caption"=> false,
-                    "term"=> false,
-                    "name"=> nothing,
-                    "wrap"=> true,
-                    "f_pos"=> "htpb",
-                    "f_size"=> (8, 6),
-                    "f_env"=> nothing,
-                    "f_spines"=> true,
-                    "complete"=> true,
-                    "engine"=> "julia",
-                    "option_string"=> ""
-                    }
-                   }
-                  }
+const rcParams =
+    @compat Dict{ASCIIString,Any}("figdir"=> "figures",
+                                  "usematplotlib"=> true,
+                                  "storeresults"=> false,
+                                  "cachedir"=> "cache",
+                                  "chunk"=>
+                                  Dict{ASCIIString,Any}("defaultoptions"=>
+                                                        Dict{ASCIIString,Any}("echo"=> true,
+                                                                              "results"=> "verbatim",
+                                                                              "fig"=> true,
+                                                                              "include"=> true,
+                                                                              "evaluate"=> true,
+                                                                              "caption"=> false,
+                                                                              "term"=> false,
+                                                                              "name"=> nothing,
+                                                                              "wrap"=> true,
+                                                                              "f_pos"=> "htpb",
+                                                                              "f_size"=> (8, 6),
+                                                                              "f_env"=> nothing,
+                                                                              "f_spines"=> true,
+                                                                              "complete"=> true,
+                                                                              "engine"=> "julia",
+                                                                              "option_string"=> ""
+                                                                              )
+                                                        )
+                                  )

--- a/src/readers.jl
+++ b/src/readers.jl
@@ -22,19 +22,20 @@ function read_noweb(document)
       optionstring=m.captures[1]
       #println(m.captures[1])
       if strip(optionstring)==""
-        options = Dict()
+        options = StrD()
       else
           try
               options = eval(parse("{" * optionstring * "}"))
           catch
-              options = Dict()
+              options = StrD()
               warn(string("Invalid format for chunk options line: ", lineno))
           end
       end
       haskey(options, "label") && (options["name"] = options["label"])
       haskey(options, "name") || (options["name"] = nothing)
 
-      chunk = {"type" => "doc", "content"=> content, "number" =>  docno, "start_line"=>start_line}
+      chunk = @compat Dict{ASCIIString,Any}("type" => "doc", "content"=> content,
+                                            "number" =>  docno, "start_line"=>start_line)
       docno += 1
       start_line = lineno
       push!(parsed, chunk)
@@ -42,8 +43,10 @@ function read_noweb(document)
       continue
     end
     if ismatch(codeend, line) && state=="code"
-      chunk = {"type" => "code", "content" => content, "number" => codeno,
-      "options"=>options,"optionstring"=>optionstring, "start_line"=>start_line}
+      chunk = @compat Dict{ASCIIString,Any}("type" => "code", "content" => content,
+                                            "number" => codeno, "options" => options,
+                                            "optionstring" => optionstring,
+                                            "start_line" => start_line)
       codeno+=1
       start_line = lineno
       content = ""
@@ -57,7 +60,8 @@ function read_noweb(document)
 
   #Remember the last chunk
   if content != ""
-    chunk = {"type" => "doc", "content"=> content, "number" =>  docno, "start_line"=>lineno}
+    chunk = @compat Dict{ASCIIString,Any}("type" => "doc", "content" => content,
+                                          "number" =>  docno, "start_line" => lineno)
     push!(parsed, chunk)
   end
 


### PR DESCRIPTION
This version works on my tests with Julia 0.3.3 and with Julia 0.4.0-dev.  There are still warnings generated in version 0.4.0-dev by the line

``` jl
              options = eval(parse("{" * optionstring * "}"))
```

in `src/readers.jl`  I think the best approach will be to split optionstring on ',' then split each chunk on "=>" and insert each option into the options dictionary.
