### PR TITLE
Parse the chunk options as a set of Julia expressions and store options ...

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-PyPlot
+PyCall
 Compat

--- a/examples/julia_sample.mdw
+++ b/examples/julia_sample.mdw
@@ -15,7 +15,7 @@ weave("examples/julia_sample.mdw")
 
 ## Terminal chunk
 
-<<"term"=>true>>=
+<<term=true>>=
 x = 1:10
 d = {"juliareport" => "testing"}
 y = [2, 4 ,8]
@@ -35,6 +35,6 @@ ylabel("sinc(x)")
 
 You can also include a plot with caption and hide the code:
 
-<<"echo"=>false, "caption"=>"Random walk.", "label"=>"random">>=
+<<echo=false; caption="Random walk."; label="random">>=
 plot(cumsum(randn(1000, 1)))
 @

--- a/examples/winston_sample.mdw
+++ b/examples/winston_sample.mdw
@@ -15,7 +15,7 @@ weave(Pkg.dir("JuliaReport","examples","winston_sample.mdw"), plotlib="Winston")
 
 ## Terminal chunk
 
-<<"term"=>true>>=
+<<term=true>>=
 x = 1:10
 d = {"juliareport" => "testing"}
 y = [2, 4 ,8]
@@ -36,7 +36,7 @@ ylabel("sinc(x)")
 
 You can also include a plot with caption and hide the code:
 
-<<"echo"=>false, "caption"=>"Random walk.", "label"=>"random">>=
+<<echo=false; caption="Random walk."; label="random">>=
 figure()
 plot(cumsum(randn(1000, 1)))
 @

--- a/src/config.jl
+++ b/src/config.jl
@@ -1,25 +1,25 @@
 const rcParams =
-    @compat Dict{ASCIIString,Any}("figdir"=> "figures",
-                                  "plotlib" => "PyPlot",
-                                  "storeresults"=> false,
-                                  "cachedir"=> "cache",
-                                  "chunk"=>
-                                  Dict{ASCIIString,Any}("defaultoptions"=>
-                                                        Dict{ASCIIString,Any}("echo"=> true,
-                                                                              "results"=> "verbatim",
-                                                                              "fig"=> true,
-                                                                              "include"=> true,
-                                                                              "evaluate"=> true,
-                                                                              "caption"=> false,
-                                                                              "term"=> false,
-                                                                              "name"=> nothing,
-                                                                              "wrap"=> true,
-                                                                              "f_pos"=> "htpb",
-                                                                              "f_size"=> (8, 6),
-                                                                              "f_env"=> nothing,
-                                                                              "f_spines"=> true,
-                                                                              "complete"=> true,
-                                                                              "engine"=> "julia",
-                                                                              "option_string"=> "")
-                                                        )
-                                  )
+    @compat Dict{Symbol,Any}(:figdir=> "figures",
+                             :plotlib => "PyPlot",
+                             :storeresults=> false,
+                             :cachedir=> "cache",
+                             :chunk=>
+                             Dict{Symbol,Any}(:defaultoptions=>
+                                              Dict{Symbol,Any}(:echo=> true,
+                                                               :results=> "verbatim",
+                                                               :fig=> true,
+                                                               :include=> true,
+                                                               :evaluate=> true,
+                                                               :caption=> false,
+                                                               :term=> false,
+                                                               :name=> nothing,
+                                                               :wrap=> true,
+                                                               :f_pos=> "htpb",
+                                                               :f_size=> (8, 6),
+                                                               :f_env=> nothing,
+                                                               :f_spines=> true,
+                                                               :complete=> true,
+                                                               :engine=> "julia",
+                                                               :option_string=> "")
+                                              )
+                             )


### PR DESCRIPTION
...in a Dict{Symbol,Any}

This version is okay on `examples/julia_sample.mdw` but on `examples/winston_sample.mdw` produces

``` jl
optionstring = "term=true"
options = Dict{Symbol,Any}(:term=>true,:name=>nothing)
optionstring = ""
options = Dict{Symbol,Any}(:name=>nothing)
optionstring = "echo=false; caption=\"Random walk.\"; label=\"random\""
options = Dict{Symbol,Any}(:echo=>false,:label=>"random",:name=>"random",:caption=>"Random walk.")
INFO: Weaving chunk 1 from line 18


WARNING: deprecated syntax "{a=>b, ...}".
Use "Dict{Any,Any}(a=>b, ...)" instead.
INFO: Weaving chunk 2 from line 28

figures/winston_sample_nothing_1.png
ERROR: key not found: :page_margin
 in getindex at ./dict.jl:640
 in getattr at /home/bates/.julia/v0.4/Winston/src/Winston.jl:1056
 in page_compose at /home/bates/.julia/v0.4/Winston/src/Winston.jl:1782
 in savepng at /home/bates/.julia/v0.4/Winston/src/Winston.jl:1844
 in savefig at /home/bates/.julia/v0.4/Winston/src/Winston.jl:1854
 in savefig at /home/bates/.julia/v0.4/Winston/src/plot.jl:14
 in savefigs_winston at /home/bates/.julia/v0.4/JuliaReport/src/JuliaReport.jl:187
 in savefigs at /home/bates/.julia/v0.4/JuliaReport/src/JuliaReport.jl:144
 in run at /home/bates/.julia/v0.4/JuliaReport/src/JuliaReport.jl:133
 in weave at /home/bates/.julia/v0.4/JuliaReport/src/JuliaReport.jl:58
```

but I don't know enough about the Winston device to be able to debug that.

I left some calls to the `@show` macro in the sources.  That is the preferred way of producing debugging output.
