### PR TITLE
disable figure processing for no-eval chunks

### DIFF
--- a/src/Weave.jl
+++ b/src/Weave.jl
@@ -190,6 +190,7 @@ function run(parsed)
 
             if !chunk[:eval]
                 chunk[:result] = ""
+                chunk[:fig] = false
                 parsed[i] = copy(chunk)
                 i += 1
                 continue #Do nothing if eval is false


### PR DESCRIPTION
Error origin: when `eval=false` is set, a figure processing need to be disabled, otherwise a formatter tries to process a non-existed figure and falls with a following error:

```
ERROR: key not found: :figure
 in getindex at dict.jl:617
 in format at /.julia/v0.3/Weave/src/formatters.jl:39
 in weave at /.julia/v0.3/Weave/src/Weave.jl:101
 in process_options at ./client.jl:213
 in _start at ./client.jl:354
 in _start_3B_1720 at /usr/bin/../lib/x86_64-linux-gnu/julia/sys.so
```
