### PR TITLE
Changes to pandoc call and to templates

### DIFF
--- a/src/pandoc.jl
+++ b/src/pandoc.jl
@@ -21,7 +21,7 @@ function pandoc2html(formatted::AbstractString, doc::WeaveDoc, outname::Abstract
 
   try
     pandoc_out, pandoc_in, proc = readandwrite(`pandoc -R -s --mathjax="" --self-contained --highlight-style=tango
-    --template $html_template --include-in-header=$css_template
+    --template $html_template -c $css_template
      -V wversion=$wversion -V wtime=$wtime -V wsource=$wsource
      -o $outname`)
     println(pandoc_in, formatted)

--- a/templates/pandoc_skeleton.css
+++ b/templates/pandoc_skeleton.css
@@ -506,10 +506,25 @@ pre {
   color: #333;
   word-break: break-all;
   word-wrap: break-word;
+  background-color: #ffffff;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+pre.sourceCode.julia {
+  display: block;
+  padding: 9.5px;
+  margin: 0 0 10px;
+  font-size: 13px;
+  line-height: 1.42857143;
+  color: #333;
+  word-break: break-all;
+  word-wrap: break-word;
   background-color: #f5f5f5;
   border: 1px solid #ccc;
   border-radius: 4px;
 }
+
 code,
 kbd,
 pre,
@@ -520,9 +535,17 @@ code {
   padding: 2px 4px;
   font-size: 90%;
 
-  background-color: #f9f2f4;
+  background-color: #ffffff;
   border-radius: 4px;
 }
+
+code.sourceCode.julia {
+  padding: 2px 4px;
+  font-size: 90%;
+  background-color: #f5f5f5;
+  border-radius: 4px;
+}
+
 
 @media (min-width: 400px) {}
 @media (min-width: 550px) {}

--- a/templates/pandoc_skeleton.html
+++ b/templates/pandoc_skeleton.html
@@ -30,6 +30,10 @@ $highlighting-css$
 </style>
 $endif$
 
+$for(css)$
+  <link rel="stylesheet" href="$css$">
+$endfor$
+
 </head>
 <body>
 <div class ="container">


### PR DESCRIPTION
This PR aims at accomplishing three things:

- [x] change how `pandoc` is called. Instead of using `--include-in-header=$css_template` now the call uses -c $css_template`. 

- [x] Adds a template for css to `pandoc_skeleton.html`. It now allows for multiple css stylesheets being used. This is required to make the change in pandoc call to actually insert the `css` template. Notice that now the css template is added after the css template of the highlighter. This is important because as it is now the styles of the template are over-written by those of the highlighter. 

- [x] Allow different background colors for julia-code and the results. This changes the resulting html only when the new option `display=true`.  