### PR TITLE
Correct mathjax issue

### DIFF
--- a/templates/pandoc_skeleton.css
+++ b/templates/pandoc_skeleton.css
@@ -1,12 +1,3 @@
-
-
-<script type="text/javascript">
-  var fileref=document.createElement('script')
-  fileref.setAttribute("type","text/javascript")
-  fileref.setAttribute("src", "http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML")
-  document.getElementsByTagName("head")[0].appendChild(fileref)
-</script>
-
 <style type="text/css">
 @font-face {
   font-family: 'Raleway';

--- a/templates/pandoc_skeleton.html
+++ b/templates/pandoc_skeleton.html
@@ -15,6 +15,12 @@ $if(keywords)$
 $endif$
   <title>$if(title-prefix)$$title-prefix$ – $endif$$pagetitle$</title>
 
+  <script type="text/javascript">
+    var fileref=document.createElement('script')
+    fileref.setAttribute("type","text/javascript")
+    fileref.setAttribute("src", "http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML")
+    document.getElementsByTagName("head")[0].appendChild(fileref)
+  </script>
 
 $if(math)$
   $math$


### PR DESCRIPTION
This fix a bug introduced in #42. The script tag calling  mathjax was in `pandoc_skeleton.css` and it is not correctly parsed by the new way in which pandoc is called. Now the script is in `pandoc_skeleton.html`.