### PR TITLE
Fix inline code snippets output

### DIFF
--- a/src/run.jl
+++ b/src/run.jl
@@ -178,6 +178,7 @@ function run_inline(inline::InlineCode, report::Report, SandBox::Module)
 
     output = chunks[1].output
     startswith(output, "\n") && (output = replace(output, "\n", "", 1))
+    endswith(output, "\n") && (output = output[1:end-1])
     inline.output = output
     inline.rich_output = chunks[1].rich_output
     inline.figures = chunks[1].figures


### PR DESCRIPTION
Inline code snippets with super-simple things like ``` `j length([1,2,3]` ``` append a `\n` at the end, breaking the flow of text. This PR fixes this issue by stripping at most one `\n` from the end.

Looking at the code though, would it make sense to have `output = strip(output, [' ', '\t', '\n'])`?

