### PR TITLE
Removed superfluous space which broke the hugo parser.

### DIFF
--- a/src/formatters.jl
+++ b/src/formatters.jl
@@ -427,7 +427,7 @@ function formatfigures(chunk, docformat::Hugo)
             caption = chunk.options[:fig_cap]
             title_spec = caption == nothing ? "" : "title=\"$(caption)\" "
         end
-        "{{< figure src=\"$(joinpath(relpath, fig))\" $(title_spec) > }}"
+        "{{< figure src=\"$(joinpath(relpath, fig))\" $(title_spec) >}}"
     end
     mapreduce(format_shortcode, *, "", enumerate(chunk.figures))
 end


### PR DESCRIPTION
Please merge this trivial PR, I somehow missed this because the first plot shows up OK.