### PR TITLE
Add unicode symbol support based on CMU and Latin Modern fonts

### DIFF
--- a/templates/julia_tex.tpl
+++ b/templates/julia_tex.tpl
@@ -3,15 +3,23 @@
 \usepackage[a4paper,text={16.5cm,25.2cm},centering]{geometry}
 \usepackage{lmodern}
 \usepackage{amssymb,amsmath}
-\usepackage{ifxetex}
-\ifxetex
-  \usepackage{mathspec}
-\fi
 \usepackage{graphics}
 \usepackage{microtype}
 \usepackage{hyperref}
 \setlength{\parindent}{0pt}
 \setlength{\parskip}{1.2ex}
+
+\usepackage{ifxetex,ifluatex}
+\newif\ifxetexorluatex
+\ifxetex
+  \xetexorluatextrue
+\else
+  \ifluatex
+    \xetexorluatextrue
+  \else
+    \xetexorluatexfalse
+  \fi
+\fi
 
 \hypersetup
        {   pdfauthor = { {{{:author}}} },
@@ -36,6 +44,14 @@
 {{/:date}}
 
 {{{ :highlight }}}
+
+\ifxetexorluatex
+  \usepackage{fontspec}
+  \setmainfont{CMU Serif Roman}
+  \setmonofont{CMU Typewriter Text}
+  \usepackage{unicode-math}
+  \setmathfont{Latin Modern Math}
+\fi
 
 \begin{document}
 


### PR DESCRIPTION
Here's an attempt at fixing #90 for luatex and xelatex.  I'm no tex font expert, but the CMU fonts have the following benefits, from fiddling with several combinations:

* `Latin Modern Math` has the clean look which really sets latex typeset math apart, as it's based on the original Computer Modern fonts.
* `CMU Serif Roman` and `CMU Typewriter Text` are also just modernized versions of Computer Modern, so the seem to fit in fairly well.  They have the advantage over `Latin Modern Roman` and `Latin Modern Mono` in supporting basic symbols.