### PR TITLE
Replace usepackage graphics with graphicx

### DIFF
--- a/templates/julia_tex.tpl
+++ b/templates/julia_tex.tpl
@@ -3,7 +3,7 @@
 \usepackage[a4paper,text={16.5cm,25.2cm},centering]{geometry}
 \usepackage{lmodern}
 \usepackage{amssymb,amsmath}
-\usepackage{graphics}
+\usepackage{graphicx}
 \usepackage{microtype}
 \usepackage{hyperref}
 \setlength{\parindent}{0pt}


### PR DESCRIPTION
I had issues with the chunk option `out_width` unless I replaced the use of the old `graphics` package with the newer `graphicx`
See https://tex.stackexchange.com/questions/23075/packages-graphics-vs-graphicx for additional info