### PR TITLE
Use align for ```math blocks

### DIFF
--- a/src/Markdown2HTML.jl
+++ b/src/Markdown2HTML.jl
@@ -157,7 +157,7 @@ end
 
 function html(io::IO, tex::LaTeX)
     withtag(io, :p, :class => "math") do
-        write(io, string("\\[", tex.formula, "\\]"))
+        write(io, string("\\[\n\\begin{align}\n", tex.formula, "\n\\end{align}\n\\]"))
     end
 end
 

--- a/src/format.jl
+++ b/src/format.jl
@@ -4,6 +4,7 @@ using Compat
 using Dates
 using Markdown
 using REPL.REPLCompletions: latex_symbols
+import Markdown.latex
 
 function format(doc::WeaveDoc)
     formatted = AbstractString[]
@@ -301,7 +302,6 @@ function indent(text, nindent)
                     string(repeat(" ", nindent), x), split(text, "\n")), "\n")
 end
 
-
 function wraplines(text, line_width=75)
     result = AbstractString[]
     lines = split(text, "\n")
@@ -323,4 +323,8 @@ result = ""
         text = text[(line_width+1):end]
     end
 result *= text
+end
+
+function latex(io::IO, tex::Markdown.LaTeX)
+    write(io, string("\n\\begin{align}\n", tex.formula, "\n\\end{align}\n"))
 end

--- a/src/pandoc.jl
+++ b/src/pandoc.jl
@@ -112,6 +112,7 @@ function run_latex(doc::WeaveDoc, outname, latex_cmd = "xelatex")
   textmp = mktempdir(".")
   try
     out = read(`$latex_cmd -shell-escape $xname -aux-directory $textmp -include-directory $(doc.cwd)`, String)
+    out = read(`$latex_cmd -shell-escape $xname -aux-directory $textmp -include-directory $(doc.cwd)`, String)
     rm(xname)
     rm(textmp, recursive=true)
     cd(old_wd)


### PR DESCRIPTION
Quick fix to #142, use `align` environment for math blocks.