### PR TITLE
use Base.show

### DIFF
--- a/src/Markdown2HTML.jl
+++ b/src/Markdown2HTML.jl
@@ -226,11 +226,4 @@ htmlinline(io::IO, x) = tohtml(io, x)
 
 html(md) = sprint(html, md)
 
-function Base.show(io::IO, ::MIME"text/html", md::MD)
-    withtag(io, :div, :class=>"markdown") do
-        html(io, md)
-    end
-end
-
-
 end

--- a/src/Markdown2HTML.jl
+++ b/src/Markdown2HTML.jl
@@ -226,7 +226,7 @@ htmlinline(io::IO, x) = tohtml(io, x)
 
 html(md) = sprint(html, md)
 
-function show(io::IO, ::MIME"text/html", md::MD)
+function Base.show(io::IO, ::MIME"text/html", md::MD)
     withtag(io, :div, :class=>"markdown") do
         html(io, md)
     end


### PR DESCRIPTION
There's one place where a `show` method is defined that's not `Base.show`.  I get errors like this

```
julia> weave("cogsci19/cogsci.jmd", mod=Main)
[ Info: Weaving chunk 1 from line 1
ERROR: MethodError: no method matching show(::Base.GenericIOBuffer{Array{UInt8,1}}, ::MIME{Symbol("text/plain")}, ::Symbol)
You may have intended to import Base.show
Closest candidates are:
  show(::IO, ::MIME{Symbol("text/html")}, ::Markdown.MD) at /home/dave/.julia/dev/Weave/src/Markdown2HTML.jl:230
Stacktrace:
 [1] #sprint#324(::Nothing, ::Int64, ::Function, ::Function, ::MIME{Symbol("text/plain")}, ::Vararg{Any,N} where N) at ./strings/io.jl:101
 [2] sprint(::Function, ::MIME{Symbol("text/plain")}, ::Vararg{Any,N} where N) at ./strings/io.jl:97
 [3] tohtml(::Base.GenericIOBuffer{Array{UInt8,1}}, ::MIME{Symbol("text/plain")}, ::Symbol) at /home/dave/.julia/dev/Weave/src/Markdown2HTML.jl:12
 [4] tohtml(::Base.GenericIOBuffer{Array{UInt8,1}}, ::Symbol) at /home/dave/.julia/dev/Weave/src/Markdown2HTML.jl:34
 [5] html(::Base.GenericIOBuffer{Array{UInt8,1}}, ::Symbol) at /home/dave/.julia/dev/Weave/src/Markdown2HTML.jl:164
 [6] html(::Base.GenericIOBuffer{Array{UInt8,1}}, ::Array{Any,1}) at /home/dave/.julia/dev/Weave/src/Markdown2HTML.jl:87
 [7] html(::Base.GenericIOBuffer{Array{UInt8,1}}, ::Markdown.MD) at /home/dave/.julia/dev/Weave/src/Markdown2HTML.jl:92
 [8] #sprint#324(::Nothing, ::Int64, ::Function, ::Function, ::Markdown.MD) at ./strings/io.jl:101
 [9] sprint at ./strings/io.jl:97 [inlined]
 [10] html(::Markdown.MD) at /home/dave/.julia/dev/Weave/src/Markdown2HTML.jl:227
 [11] format_chunk(::Weave.DocChunk, ::Dict{Symbol,Any}, ::Weave.JMarkdown2HTML) at /home/dave/.julia/dev/Weave/src/format.jl:132
 [12] format(::Weave.WeaveDoc) at /home/dave/.julia/dev/Weave/src/format.jl:33
 [13] #weave#10(::Symbol, ::Symbol, ::Symbol, ::Dict{Any,Any}, ::Module, ::String, ::Nothing, ::String, ::Symbol, ::Bool, ::Nothing, ::Nothing, ::Nothing, ::Array{String,1}, ::String, ::typeof(weave), ::String) at /home/dave/.julia/dev/Weave/src/Weave.jl:112
 [14] (::getfield(Weave, Symbol("#kw##weave")))(::NamedTuple{(:mod,),Tuple{Module}}, ::typeof(weave), ::String) at ./none:0
 [15] top-level scope at none:0
```

My hunch is that somehow the one non-Base show method being defined is somehow blocking the Base ones, but I could be wrong.  Changing the function definition to be `Base.show` fixes the error but then I get warnings like

```
julia> using Weave
[ Info: Recompiling stale cache file /home/dave/.julia/compiled/v1.0/Weave/9EzOc.ji for Weave [44d3d7a6-8a23-5bf8-98c5-b353f8df5ec9]
WARNING: Method definition show(IO, Base.MIME{Symbol("text/html")}, Markdown.MD) in module Markdown at /build/julia/src/julia-1.0.3/usr/share/julia/stdlib/v1.0/Markdown/src/render/html.jl:188 overwritten in module Markdown2HTML at /home/dave/.julia/dev/Weave/src/Markdown2HTML.jl:230.
WARNING: Method definition latex(IO, Markdown.LaTeX) in module Markdown at /build/julia/src/julia-1.0.3/usr/share/julia/stdlib/v1.0/Markdown/src/IPython/IPython.jl:28 overwritten in module Weave at /home/dave/.julia/dev/Weave/src/format.jl:329.
```

So maybe this isn't the right approach but I'm proposing it here just in case.  @dmbates pointed this out in #149 (even though it didn't address the underlying problem there).