### PR TITLE
check fig_ext to choose preferred mimetype in display(::Report, d)

### DIFF
--- a/src/display_methods.jl
+++ b/src/display_methods.jl
@@ -31,9 +31,17 @@ const default_mime_types = ["image/svg+xml", "image/png", "text/html", "text/pla
 #From IJulia as a reminder
 #const supported_mime_types = [ "text/html", "text/latex", "image/svg+xml", "image/png", "image/jpeg", "text/plain", "text/markdown" ]
 
+const mimetype_from_fig_ext =
+    Dict(".png" => "image/png",
+         ".jpg" => "image/jpeg",
+         ".jpeg" => "image/jpeg",
+         ".svg" => "image/svg+xml",
+         ".pdf" => "application/pdf")
+
 function Base.display(report::Report, data)
     #Set preferred mimetypes for report based on format
-    for m in report.mimetypes
+    fig_ext = report.cur_chunk.options[:fig_ext]
+    for m in Iterators.flatten(((mimetype_from_fig_ext[fig_ext], ), report.mimetypes))
         if showable(m, data)
             try
                 if !istextmime(m)


### PR DESCRIPTION
This might fix #130 (it at least works for my case to force pandoc formatter to generate .pdf files with Plots.jl).

I'm not sure about using `report.cur_chunk.options[:fig_ext]`; again, in the document I'm working on this is always defined when it hits the `display` method, but I'm not sure if you intend it to be reliable for this kind of use case...