### PR TITLE
Remove precompile statement

### DIFF
--- a/src/Weave.jl
+++ b/src/Weave.jl
@@ -1,4 +1,3 @@
-__precompile__()
 module Weave
 import Highlights
 using Compat


### PR DESCRIPTION
This isn't needed in the latest versions of Julia.