### PR TITLE
Fix notebook()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ test/**/*.html
 test/**/*.pdf
 test/**/*.png
 test/**/chunk_options.jl
+test/**/*.ipynb
 !test/**/*ref.*
 
 doc/build

--- a/Project.toml
+++ b/Project.toml
@@ -24,11 +24,9 @@ YAML = ">=0.3.0"
 
 [extras]
 Cairo = "159f3aea-2a34-519c-b102-8c37f9878175"
-Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"
 Gadfly = "c91e804a-d5a3-530f-b6f0-dfbca275c004"
-IJulia = "7073ff75-c697-5162-941a-fcdaad2a7d2a"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Plots", "Gadfly", "Cairo", "IJulia", "Conda"]
+test = ["Test", "Plots", "Gadfly", "Cairo"]

--- a/Project.toml
+++ b/Project.toml
@@ -24,10 +24,11 @@ YAML = ">=0.3.0"
 
 [extras]
 Cairo = "159f3aea-2a34-519c-b102-8c37f9878175"
+Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"
 Gadfly = "c91e804a-d5a3-530f-b6f0-dfbca275c004"
+IJulia = "7073ff75-c697-5162-941a-fcdaad2a7d2a"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-IJulia = "7073ff75-c697-5162-941a-fcdaad2a7d2a"
 
 [targets]
-test = ["Test", "Plots", "Gadfly", "Cairo", "IJulia"]
+test = ["Test", "Plots", "Gadfly", "Cairo", "IJulia", "Conda"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,32 +1,33 @@
 name = "Weave"
 uuid = "44d3d7a6-8a23-5bf8-98c5-b353f8df5ec9"
-version="0.9.0"
+version = "0.9.0"
 
 [deps]
-Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
-Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
-Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
-REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
-Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
-JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Highlights = "eafb193a-b7ab-5a9e-9068-77385905fa72"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 Mustache = "ffc61752-8dc7-55ee-8c37-f3e9cdd09e70"
-YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
+Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [compat]
 Highlights = ">=0.3.1"
+Mustache = ">=0.4.1"
 Plots = ">=0.19.0"
 YAML = ">=0.3.0"
-Mustache = ">=0.4.1"
 
 [extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
-Gadfly = "c91e804a-d5a3-530f-b6f0-dfbca275c004"
 Cairo = "159f3aea-2a34-519c-b102-8c37f9878175"
+Gadfly = "c91e804a-d5a3-530f-b6f0-dfbca275c004"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+IJulia = "7073ff75-c697-5162-941a-fcdaad2a7d2a"
 
 [targets]
-test = ["Test", "Plots", "Gadfly", "Cairo"]
+test = ["Test", "Plots", "Gadfly", "Cairo", "IJulia"]

--- a/Project.toml
+++ b/Project.toml
@@ -24,9 +24,11 @@ YAML = ">=0.3.0"
 
 [extras]
 Cairo = "159f3aea-2a34-519c-b102-8c37f9878175"
+Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"
 Gadfly = "c91e804a-d5a3-530f-b6f0-dfbca275c004"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+IJulia = "7073ff75-c697-5162-941a-fcdaad2a7d2a"
 
 [targets]
-test = ["Test", "Plots", "Gadfly", "Cairo"]
+test = ["Test", "Plots", "Gadfly", "Cairo", "Conda", "IJulia"]

--- a/doc/src/notebooks.md
+++ b/doc/src/notebooks.md
@@ -13,15 +13,17 @@ weave("notebook.ipynb")
 ## Output to Jupyter notebooks
 
 As of Weave 0.5.1. there is new `notebook` method to convert Weave documents
-to Jupyter notebooks using [nbconvert](http://nbconvert.readthedocs.io/en/latest/execute_api.html). The code **is not executed by Weave** 
-and the output doesn't always work properly, 
+to Jupyter notebooks using [nbconvert](http://nbconvert.readthedocs.io/en/latest/execute_api.html). The code **is not executed by Weave**
+and the output doesn't always work properly,
 see [#116](https://github.com/mpastell/Weave.jl/issues/116).
 
 ```@docs
 notebook(source::String, out_path=:pwd)
 ```
 
-You might wan't to use the `convert_doc` method below instead and run the code in Jupyter.
+You might want to use the `convert_doc` method below instead and run the code in Jupyter.
+
+You can select the `jupyter` used to execute the notebook with the `jupyter_path` argument (this defaults to the string "jupyter," i.e., whatever you have linked to that location.)
 
 ## Converting between formats
 

--- a/src/Weave.jl
+++ b/src/Weave.jl
@@ -188,10 +188,13 @@ function notebook(source::String, out_path=:pwd, timeout=-1, nbconvert_options=[
   converted = convert_doc(doc, NotebookOutput())
   doc.cwd = get_cwd(doc, out_path)
   outfile = get_outname(out_path, doc, ext="ipynb")
+  @warn "Reached line 191. "
+
 
   open(outfile, "w") do f
     write(f, converted)
   end
+  @warn "Reached line 197. "
 
   @info("Running nbconvert")
   out = read(`$jupyter_path nbconvert --ExecutePreprocessor.timeout=$timeout --to notebook --execute $outfile  $nbconvert_options --output $outfile`, String)

--- a/src/Weave.jl
+++ b/src/Weave.jl
@@ -188,13 +188,10 @@ function notebook(source::String, out_path=:pwd, timeout=-1, nbconvert_options=[
   converted = convert_doc(doc, NotebookOutput())
   doc.cwd = get_cwd(doc, out_path)
   outfile = get_outname(out_path, doc, ext="ipynb")
-  @warn "Reached line 191. "
-
 
   open(outfile, "w") do f
     write(f, converted)
   end
-  @warn "Reached line 197. "
 
   @info("Running nbconvert")
   out = read(`$jupyter_path nbconvert --ExecutePreprocessor.timeout=$timeout --to notebook --execute $outfile  $nbconvert_options --output $outfile`, String)

--- a/src/Weave.jl
+++ b/src/Weave.jl
@@ -171,7 +171,7 @@ function weave(doc::AbstractString, doctype::AbstractString)
 end
 
 """
-  notebook(source::String, out_path=:pwd, timeout=-1, nbconvert_options="", jupyter_path = "jupyter")
+  notebook(source::String; out_path=:pwd, timeout=-1, nbconvert_options="", jupyter_path = "jupyter")
 
 Convert Weave document `source` to Jupyter notebook and execute the code
 using nbconvert. **Ignores** all chunk options
@@ -183,7 +183,7 @@ using nbconvert. **Ignores** all chunk options
 * `nbconvert_options`: string of additional options to pass to nbconvert, such as `--allow-errors`
 * `jupyter_path`: Path/command for the Jupyter you want to use. Defaults to "jupyter," which runs whatever is linked/alias to that.
 """
-function notebook(source::String, out_path=:pwd, timeout=-1, nbconvert_options=[], jupyter_path = "jupyter")
+function notebook(source::String; out_path=:pwd, timeout=-1, nbconvert_options=[], jupyter_path = "jupyter")
   doc = read_doc(source)
   converted = convert_doc(doc, NotebookOutput())
   doc.cwd = get_cwd(doc, out_path)

--- a/src/Weave.jl
+++ b/src/Weave.jl
@@ -171,18 +171,19 @@ function weave(doc::AbstractString, doctype::AbstractString)
 end
 
 """
-  notebook(source::String, out_path=:pwd, timeout=-1, nbconvert_options="")
+  notebook(source::String, out_path=:pwd, timeout=-1, nbconvert_options="", jupyter_path = "jupyter")
 
 Convert Weave document `source` to Jupyter notebook and execute the code
-using nbconvert. Requires IJulia. **Ignores** all chunk options
+using nbconvert. **Ignores** all chunk options
 
 * `out_path`: Path where the output is generated. Can be: `:doc`: Path of the source document,
    `:pwd`: Julia working directory, `"somepath"`: Path as a
     String e.g `"/home/mpastell/weaveout"`
 * `timeout`: nbconvert cell timeout in seconds. Defaults to -1 (no timeout)
 * `nbconvert_options`: string of additional options to pass to nbconvert, such as `--allow-errors`
+* `jupyter_path`: Path/command for the Jupyter you want to use. Defaults to "jupyter," which runs whatever is linked/alias to that.
 """
-function notebook(source::String, out_path=:pwd, timeout=-1, nbconvert_options=[])
+function notebook(source::String, out_path=:pwd, timeout=-1, nbconvert_options=[], jupyter_path = "jupyter")
   doc = read_doc(source)
   converted = convert_doc(doc, NotebookOutput())
   doc.cwd = get_cwd(doc, out_path)
@@ -193,8 +194,7 @@ function notebook(source::String, out_path=:pwd, timeout=-1, nbconvert_options=[
   end
 
   @info("Running nbconvert")
-  Base.eval(Main, Meta.parse("import IJulia"))
-  out = read(`$(Main.IJulia.JUPYTER) nbconvert --ExecutePreprocessor.timeout=$timeout --to notebook --execute $outfile  $nbconvert_options --output $outfile`, String)
+  out = read(`$jupyter_path nbconvert --ExecutePreprocessor.timeout=$timeout --to notebook --execute $outfile  $nbconvert_options --output $outfile`, String)
 end
 
 

--- a/test/documents/jupyter_test.jmd
+++ b/test/documents/jupyter_test.jmd
@@ -1,0 +1,17 @@
+Here's some text
+
+And here's some code
+
+```julia
+    x = 1
+    y = 2
+    @show x + y
+```
+
+Here's some more complicated code
+
+```julia
+    @code_native +(1.0, π)
+    using Test
+    @test 1 == 1
+```

--- a/test/notebooks.jl
+++ b/test/notebooks.jl
@@ -1,4 +1,5 @@
-file = joinpath(@__DIR__, "documents", "include_test.jmd")
+file = joinpath(@__DIR__, "documents", "jupyter_test.jmd")
+using IJulia
 
-Weave.notebook(file, "temp_notebook.ipynb")
-@test "temp_notebook.ipynb" ∈ readdir(@__DIR__)
+Weave.notebook(file)
+@test "temp_notebook.ipynb" ∈ readdir(@__DIR__) # test if the result was weaved

--- a/test/notebooks.jl
+++ b/test/notebooks.jl
@@ -1,0 +1,4 @@
+file = joinpath(@__DIR__, "documents", "include_test.jmd")
+
+Weave.notebook(file, "temp_notebook.ipynb")
+@test "temp_notebook.ipynb" ∈ readdir(@__DIR__)

--- a/test/notebooks.jl
+++ b/test/notebooks.jl
@@ -1,5 +1,8 @@
 file = joinpath(@__DIR__, "documents", "jupyter_test.jmd")
-using IJulia
+using IJulia, Conda
 
-Weave.notebook(file)
+Conda.add("jupyter")
+Conda.add("nbconvert")
+
+Weave.notebook(file, jupyter_path = joinpath(Conda.ROOTENV, "bin", "jupyter"))
 @test "temp_notebook.ipynb" ∈ readdir(@__DIR__) # test if the result was weaved

--- a/test/notebooks.jl
+++ b/test/notebooks.jl
@@ -1,8 +1,7 @@
 file = joinpath(@__DIR__, "documents", "jupyter_test.jmd")
 using IJulia, Conda
 
-Conda.add("jupyter")
-Conda.add("nbconvert")
+Conda.add("nbconvert") # should be the same as IJulia.JUPYTER, i.e. the miniconda Python
 
-Weave.notebook(file, jupyter_path = joinpath(Conda.ROOTENV, "bin", "jupyter"))
+Weave.notebook(file, jupyter_path = IJulia.JUPYTER)
 @test "temp_notebook.ipynb" ∈ readdir(@__DIR__) # test if the result was weaved

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,62 +2,62 @@ using Weave
 using Test
 
 @testset "Weave" begin
-    # @testset "Chunk options" begin
-    #     @info("Test: Chunk options")
-    #     include("chunk_options.jl")
-    # end
-    #
-    # @testset "Error handling " begin
-    #     @info("Testing error handling")
-    #     include("errors_test.jl")
-    # end
-    #
-    # @testset "Eval in module" begin
-    #     include("sandbox_test.jl")
-    # end
-    #
-    # @testset "Conversions" begin
-    #     @info("Test: Converting")
-    #     include("convert_test.jl")
-    # end
-    #
-    # @testset "Formatters" begin
-    #     @info("Testing formatters")
-    #     include("formatter_test.jl")
-    #     include("markdown_test.jl")
-    #     @info("Testing figure formatters")
-    #     include("figureformatter_test.jl")
-    # end
-    #
-    # @testset "Rich output" begin
-    #     @info("Testing rich output")
-    #     include("rich_output.jl")
-    # end
-    #
-    # @testset "Plots" begin
-    #     @info("Test: Weaving with Plots.jl")
-    #     include("plotsjl_test.jl")
-    # end
-    #
-    # @testset "Cache" begin
-    #     @info("Testing cache")
-    #     include("cache_test.jl")
-    # end
-    #
-    # @testset "Gadfly" begin
-    #     @info("Test: Weaving with Gadfly.jl")
-    #     include("gadfly_formats.jl")
-    # end
-    #
-    # @testset "Header options" begin
-    #     @info("Testing header options")
-    #     include("options_test.jl")
-    # end
-    #
-    # @testset "Inline code" begin
-    #     @info("Testing inline code")
-    #     include("inline_test.jl")
-    # end
+    @testset "Chunk options" begin
+        @info("Test: Chunk options")
+        include("chunk_options.jl")
+    end
+
+    @testset "Error handling " begin
+        @info("Testing error handling")
+        include("errors_test.jl")
+    end
+
+    @testset "Eval in module" begin
+        include("sandbox_test.jl")
+    end
+
+    @testset "Conversions" begin
+        @info("Test: Converting")
+        include("convert_test.jl")
+    end
+
+    @testset "Formatters" begin
+        @info("Testing formatters")
+        include("formatter_test.jl")
+        include("markdown_test.jl")
+        @info("Testing figure formatters")
+        include("figureformatter_test.jl")
+    end
+
+    @testset "Rich output" begin
+        @info("Testing rich output")
+        include("rich_output.jl")
+    end
+
+    @testset "Plots" begin
+        @info("Test: Weaving with Plots.jl")
+        include("plotsjl_test.jl")
+    end
+
+    @testset "Cache" begin
+        @info("Testing cache")
+        include("cache_test.jl")
+    end
+
+    @testset "Gadfly" begin
+        @info("Test: Weaving with Gadfly.jl")
+        include("gadfly_formats.jl")
+    end
+
+    @testset "Header options" begin
+        @info("Testing header options")
+        include("options_test.jl")
+    end
+
+    @testset "Inline code" begin
+        @info("Testing inline code")
+        include("inline_test.jl")
+    end
 
     @testset "Notebooks" begin
         @info("Testing Jupyter options")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -58,4 +58,9 @@ using Test
         @info("Testing inline code")
         include("inline_test.jl")
     end
+
+    @testset "Notebooks" begin
+        @info("Testing Jupyter options")
+        @include("notebooks.jl")
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,65 +2,65 @@ using Weave
 using Test
 
 @testset "Weave" begin
-    @testset "Chunk options" begin
-        @info("Test: Chunk options")
-        include("chunk_options.jl")
-    end
-
-    @testset "Error handling " begin
-        @info("Testing error handling")
-        include("errors_test.jl")
-    end
-
-    @testset "Eval in module" begin
-        include("sandbox_test.jl")
-    end
-
-    @testset "Conversions" begin
-        @info("Test: Converting")
-        include("convert_test.jl")
-    end
-
-    @testset "Formatters" begin
-        @info("Testing formatters")
-        include("formatter_test.jl")
-        include("markdown_test.jl")
-        @info("Testing figure formatters")
-        include("figureformatter_test.jl")
-    end
-
-    @testset "Rich output" begin
-        @info("Testing rich output")
-        include("rich_output.jl")
-    end
-
-    @testset "Plots" begin
-        @info("Test: Weaving with Plots.jl")
-        include("plotsjl_test.jl")
-    end
-
-    @testset "Cache" begin
-        @info("Testing cache")
-        include("cache_test.jl")
-    end
-
-    @testset "Gadfly" begin
-        @info("Test: Weaving with Gadfly.jl")
-        include("gadfly_formats.jl")
-    end
-
-    @testset "Header options" begin
-        @info("Testing header options")
-        include("options_test.jl")
-    end
-
-    @testset "Inline code" begin
-        @info("Testing inline code")
-        include("inline_test.jl")
-    end
+    # @testset "Chunk options" begin
+    #     @info("Test: Chunk options")
+    #     include("chunk_options.jl")
+    # end
+    #
+    # @testset "Error handling " begin
+    #     @info("Testing error handling")
+    #     include("errors_test.jl")
+    # end
+    #
+    # @testset "Eval in module" begin
+    #     include("sandbox_test.jl")
+    # end
+    #
+    # @testset "Conversions" begin
+    #     @info("Test: Converting")
+    #     include("convert_test.jl")
+    # end
+    #
+    # @testset "Formatters" begin
+    #     @info("Testing formatters")
+    #     include("formatter_test.jl")
+    #     include("markdown_test.jl")
+    #     @info("Testing figure formatters")
+    #     include("figureformatter_test.jl")
+    # end
+    #
+    # @testset "Rich output" begin
+    #     @info("Testing rich output")
+    #     include("rich_output.jl")
+    # end
+    #
+    # @testset "Plots" begin
+    #     @info("Test: Weaving with Plots.jl")
+    #     include("plotsjl_test.jl")
+    # end
+    #
+    # @testset "Cache" begin
+    #     @info("Testing cache")
+    #     include("cache_test.jl")
+    # end
+    #
+    # @testset "Gadfly" begin
+    #     @info("Test: Weaving with Gadfly.jl")
+    #     include("gadfly_formats.jl")
+    # end
+    #
+    # @testset "Header options" begin
+    #     @info("Testing header options")
+    #     include("options_test.jl")
+    # end
+    #
+    # @testset "Inline code" begin
+    #     @info("Testing inline code")
+    #     include("inline_test.jl")
+    # end
 
     @testset "Notebooks" begin
         @info("Testing Jupyter options")
-        @include("notebooks.jl")
+        include("notebooks.jl")
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -59,8 +59,8 @@ using Test
         include("inline_test.jl")
     end
 
-    # @testset "Notebooks" begin
-    #     @info("Testing Jupyter options")
-    #     include("notebooks.jl")
-    # end
+    @testset "Notebooks" begin
+        @info("Testing Jupyter options")
+        include("notebooks.jl")
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -59,8 +59,8 @@ using Test
         include("inline_test.jl")
     end
 
-    @testset "Notebooks" begin
-        @info("Testing Jupyter options")
-        include("notebooks.jl")
-    end
+    # @testset "Notebooks" begin
+    #     @info("Testing Jupyter options")
+    #     include("notebooks.jl")
+    # end
 end


### PR DESCRIPTION
PR to resolve #194, which describes how `Weave.notebook()` is currently unusable unless you've happened to set up `jupyter nbconvert` on the user depot python. 

Includes documentation, a short test, and the actual substantive changes. 

Also includes a change to include notebooks in the `.gitignore`, and an `IJulia` test dependency (as `jupyter nbconvert` will call out to this package when trying to execute code). 

Let me know if this looks satisfactory, or if there's other stuff I should do. 