### PR TITLE
Fix mpastell/Weave.jl#214

### DIFF
--- a/src/run.jl
+++ b/src/run.jl
@@ -256,7 +256,7 @@ end
 function parse_input(input::AbstractString)
     parsed = Tuple{AbstractString, Any}[]
     input = lstrip(input)
-    n = length(input)
+    n = sizeof(input)
     pos = 1 #The first character is extra line end
     while pos ≤ n
         oldpos = pos


### PR DESCRIPTION
Fixes incorrect UTF-8 string handling as described in https://github.com/mpastell/Weave.jl/issues/214.