### PR TITLE
Include code from scripts inside Markdown documents

### DIFF
--- a/src/reader/markdown.jl
+++ b/src/reader/markdown.jl
@@ -4,7 +4,7 @@ function parse_markdown(document_body; is_pandoc = false)
     code_start, code_end, code_script = if is_pandoc
         r"^<<(?<options>.*?)>>=\s*$",
         r"^@\s*$",
-        nothing #TODO
+        r"a^" # match nothing TODO
     else
         r"^[`~]{3}(\{?)julia\s*([;,]?)\s*(?<options>.*?)(\}|\s*)$",
         r"^[`~]{3}\s*$",


### PR DESCRIPTION
I added support for including lines from Julia script. Following syntax is used: \`js = "path to script" => [lines]\`
For example:
\`js = "curves.jl" => [1;  5:10;]\`
will be replaced with line 1 and lines from 5 to 10 from sript `curves.jl`
