### PR TITLE
Fix some deprecations in FIR design example

### DIFF
--- a/examples/FIR_design.jl
+++ b/examples/FIR_design.jl
@@ -36,7 +36,7 @@ using Gadfly, DSP
 
 function FIRfreqz(b::Array, w = range(0, stop=π, length=1024))
     n = length(w)
-    h = Array{ComplexF32}(n)
+    h = Array{ComplexF32}(undef, n)
     sw = 0
     for i = 1:n
       for j = 1:length(b)
@@ -68,7 +68,7 @@ h = FIRfreqz(f, w)
 #' The next code chunk is executed in term mode, see the [script](FIR_design.jl) for syntax.
 #+ term=true
 
-h_db = log10(abs.(h));
+h_db = log10.(abs.(h));
 ws = w/pi*(fs/2)
 
 #+
@@ -78,6 +78,6 @@ plot(y = h_db, x = ws, Geom.line,
 
 #' And again with default options
 
-h_phase = unwrap(-atan(imag(h),real(h)))
+h_phase = unwrap(-atan.(imag(h),real(h)))
 plot(y = h_phase, x = ws, Geom.line,
     Guide.xlabel("Frequency (Hz)"), Guide.ylabel("Phase (radians)"))


### PR DESCRIPTION
Now this example runs locally for me when I `include` it.

However, I still get the error:
```julia
julia> weave(filename, out_path = :pwd)
┌ Info: Weaving chunk 1 from line 34
└   progress = 0.0
┌ Info: Weaving chunk 2 from line 60
└   progress = 0.2
┌ Info: Weaving chunk 3 from line 74
└   progress = 0.4
┌ Info: Weaving chunk 4 from line 74
└   progress = 0.6
┌ Warning: ERROR: ErrorException occurred, including output in Weaved document
└ @ Weave ~/.julia/dev/Weave/src/run.jl:224
┌ Info: Weaved all chunks
└   progress = 1
ERROR: SystemError: opening file "/tmp/jl_3kdZ8J/FIR_design_4_1.png": No such file or directory
Stacktrace:
  [1] systemerror(p::String, errno::Int32; extrainfo::Nothing)
    @ Base ./error.jl:168
  [2] #systemerror#62
    @ ./error.jl:167 [inlined]
  [3] systemerror
    @ ./error.jl:167 [inlined]
  [4] open(fname::String; lock::Bool, read::Bool, write::Nothing, create::Nothing, truncate::Nothing, append::Nothing)
    @ Base ./iostream.jl:293
  [5] open(fname::String, mode::String; lock::Bool)
    @ Base ./iostream.jl:355
  [6] open
    @ ./iostream.jl:355 [inlined]
  [7] img2base64(fig::String, cwd::String)
    @ Weave ~/.julia/dev/Weave/src/run.jl:147
  [8] embed_figures!(chunk::Weave.CodeChunk, cwd::String)
    @ Weave ~/.julia/dev/Weave/src/run.jl:140
  [9] _broadcast_getindex_evalf
    @ ./broadcast.jl:648 [inlined]
 [10] _broadcast_getindex
    @ ./broadcast.jl:621 [inlined]
 [11] getindex
    @ ./broadcast.jl:575 [inlined]
 [12] macro expansion
    @ ./broadcast.jl:984 [inlined]
 [13] macro expansion
    @ ./simdloop.jl:77 [inlined]
 [14] copyto!
    @ ./broadcast.jl:983 [inlined]
 [15] copyto!
    @ ./broadcast.jl:936 [inlined]
 [16] copy
    @ ./broadcast.jl:908 [inlined]
 [17] materialize
    @ ./broadcast.jl:883 [inlined]
 [18] embed_figures!(chunks::Vector{Weave.CodeChunk}, cwd::String)
    @ Weave ~/.julia/dev/Weave/src/run.jl:143
 [19] run_chunk
    @ ~/.julia/dev/Weave/src/run.jl:134 [inlined]
 [20] run_doc(doc::Weave.WeaveDoc; doctype::Nothing, out_path::Symbol, args::Dict{Any, Any}, mod::Nothing, fig_path::Nothing, fig_ext::Nothing, cache_path::String, cache::Symbol)
    @ Weave ~/.julia/dev/Weave/src/run.jl:74
 [21] weave(source::String; doctype::Nothing, informat::Nothing, out_path::Symbol, args::Dict{Any, Any}, mod::Nothing, fig_path::Nothing, fig_ext::Nothing, cache_path::String, cache::Symbol, template::Nothing, css::Nothing, highlight_theme::Nothing, pandoc_options::Vector{String}, latex_cmd::Vector{String}, keep_unicode::Bool)
    @ Weave ~/.julia/dev/Weave/src/Weave.jl:176
 [22] top-level scope
    @ REPL[4]:1
```
when I try to run the file with `weave`.

Fixes #437.