### PR TITLE
Update RelocatableFolders dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Weave"
 uuid = "44d3d7a6-8a23-5bf8-98c5-b353f8df5ec9"
-version = "0.10.11"
+version = "0.10.12"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
@@ -22,7 +22,7 @@ Highlights = "0.3.1, 0.4, 0.5"
 JSON = "0.21"
 Mustache = "0.4.1, 0.5, 1"
 Plots = "0.28, 0.29, 1.0"
-RelocatableFolders = "0.1"
+RelocatableFolders = "0.1,0.2,0.3,1"
 Requires = "1.0"
 YAML = "0.3, 0.4"
 julia = "1.2"

--- a/test/test_display.jl
+++ b/test/test_display.jl
@@ -10,7 +10,7 @@ DataFrame(a=rand(10))
 ```
 """; doctype = "md2html")
 @test isdefined(doc.chunks[1], :rich_output)
-@test count("<tr>", doc.chunks[1].rich_output) == 12 # additonal 2 for name and type row
+@test count("<tr", doc.chunks[1].rich_output) == 12 # additonal 2 for name and type row
 
 # limit
 n = 100000


### PR DESCRIPTION
Would be great to have a new release, as the compat on `RelocatableFolders` blocks some package updates.
I needed to relaxed a DataFrames display test - there has been some changes to the HTML display of tables...