### PR TITLE
Fix error handling tests for Julia 1.12

### DIFF
--- a/test/run/test_error.jl
+++ b/test/run/test_error.jl
@@ -39,14 +39,28 @@ err_str2 = get_err_str(err_stmt2)
 err_str3_1 = get_err_str("plot(x)")
 err_str3_2 = get_err_str("f(y")
 
+# Julia 1.12+ error messages include source locations and module names that
+# differ between include_string (used above) and Weave's execution context
+# (temp files, sandbox module). Normalize these before comparing.
+function normalize_err(s::AbstractString)
+    # ParseError locations: "@ string:1:5" (include_string) vs "@ /tmp/...:2:5" (Weave temp file)
+    s = replace(s, r"@ .+?:\d+:\d+" => "@ <loc>")
+    # UndefVarError module: "Main" (include_string) vs "Main.var\"##WeaveSandBox#N\"" (Weave sandbox)
+    s = replace(s, r"Main\.var\"##WeaveSandBox#\d+\"" => "Main")
+    # Weave uses display(err) while get_err_str uses showerror — these produce
+    # different whitespace in ParseError diagnostics. Collapse whitespace so
+    # the semantic content can be compared.
+    s = replace(s, r"\s+" => " ")
+    return s
+end
 
 let doc = mock_run(str; doctype = "github")
     get_output(i) = doc.chunks[i].output
 
     @test occursin(err_str1, get_output(1))
-    @test occursin(err_str2, get_output(2))
-    @test occursin(err_str3_1, get_output(3))
-    @test occursin(err_str3_2, get_output(3))
+    @test occursin(normalize_err(err_str2), normalize_err(get_output(2)))
+    @test occursin(normalize_err(err_str3_1), normalize_err(get_output(3)))
+    @test occursin(normalize_err(err_str3_2), normalize_err(get_output(3)))
 end
 
 # TODO: move this into chunk option tests


### PR DESCRIPTION
## Summary
- In Julia 1.12, `ParseError` messages include source locations and `UndefVarError` messages include module names
- These differ between the test's `include_string(Main, ...)` and Weave's execution context (temp files, sandbox module), causing 3 test failures
- Normalize source locations, module names, and whitespace before comparing error strings

## Test plan
- [x] `Pkg.test()` passes: 194 passed, 2 broken (pre-existing), 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)