### PR TITLE
Allow JSON.jl v1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 ## Release notes for Weave.jl
 
+### Unreleased
+
+improvements:
+- allow JSON.jl v1
+
 ### v0.10.6 – 2020/10/03
 
 improvements:

--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [compat]
 Highlights = "0.3.1, 0.4, 0.5"
-JSON = "0.21"
+JSON = "0.21, 1"
 Mustache = "0.4.1, 0.5, 1"
 Plots = "0.28, 0.29, 1.0"
 RelocatableFolders = "0.1,0.2,0.3,1"


### PR DESCRIPTION
## Summary
- Widen JSON.jl compat bound from `"0.21"` to `"0.21, 1"`
- Weave only uses `JSON.parse` and `JSON.json`, which are compatible across both versions

## Test plan
- [x] `Pkg.test()` passes with JSON v1.4.0: 194 passed, 2 broken (pre-existing), 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)