### PR TITLE
Fix error handling tests for Julia 1.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,11 @@ jobs:
         version:
           - 'lts'
           - '1'
+          - '1.12'
         os:
           - ubuntu-latest
           - macOS-latest
+          - windows-latest
         allow-failure: [false]
         include:
           - version: 'pre'
@@ -30,6 +32,9 @@ jobs:
             allow-failure: true
           - version: 'pre'
             os: macOS-latest
+            allow-failure: true
+          - version: 'pre'
+            os: windows-latest
             allow-failure: true
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,62 +6,42 @@ on:
     branches:
       - master
   pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.allow-failure }}
     strategy:
-      fail-fast: false # don't stop CI even when one of them fails
+      fail-fast: false
       matrix:
         version:
-          - '1.5'
+          - 'lts'
+          - '1'
         os:
           - ubuntu-latest
           - macOS-latest
-          # - windows-latest # TODO: test on Windows
-        arch:
-          - x64
-          - x86
         allow-failure: [false]
         include:
-          # this is so verbose... any other way to simplify this ?
-          - version: 'nightly'
+          - version: 'pre'
             os: ubuntu-latest
-            arch: x64
             allow-failure: true
-          - version: 'nightly'
-            os: ubuntu-latest
-            arch: x86
-            allow-failure: true
-          - version: 'nightly'
+          - version: 'pre'
             os: macOS-latest
-            arch: x64
             allow-failure: true
-          # - version: 'nightly'
-          #   os: windows-latest
-          #   arch: x64
-          #   allow-failure: true
-          # - version: 'nightly'
-          #   os: windows-latest
-          #   arch: x86
-          #   allow-failure: true
-        exclude:
-          - os: macOS-latest
-            arch: x86
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
-      - uses: julia-actions/julia-buildpkg@latest
-      - uses: julia-actions/julia-runtest@latest
+      - uses: julia-actions/cache@v3
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v5
         with:
           file: ./lcov.info
-          flags: unittests
-          name: codecov-umbrella
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,6 @@ jobs:
         os:
           - ubuntu-latest
           - macOS-latest
-          - windows-latest
         allow-failure: [false]
         include:
           - version: 'pre'

--- a/test/run/test_error.jl
+++ b/test/run/test_error.jl
@@ -39,14 +39,28 @@ err_str2 = get_err_str(err_stmt2)
 err_str3_1 = get_err_str("plot(x)")
 err_str3_2 = get_err_str("f(y")
 
+# Julia 1.12+ error messages include source locations and module names that
+# differ between include_string (used above) and Weave's execution context
+# (temp files, sandbox module). Normalize these before comparing.
+function normalize_err(s::AbstractString)
+    # ParseError locations: "@ string:1:5" (include_string) vs "@ /tmp/...:2:5" (Weave temp file)
+    s = replace(s, r"@ .+?:\d+:\d+" => "@ <loc>")
+    # UndefVarError module: "Main" (include_string) vs "Main.var\"##WeaveSandBox#N\"" (Weave sandbox)
+    s = replace(s, r"Main\.var\"##WeaveSandBox#\d+\"" => "Main")
+    # Weave uses display(err) while get_err_str uses showerror — these produce
+    # different whitespace in ParseError diagnostics. Collapse whitespace so
+    # the semantic content can be compared.
+    s = replace(s, r"\s+" => " ")
+    return s
+end
 
 let doc = mock_run(str; doctype = "github")
     get_output(i) = doc.chunks[i].output
 
     @test occursin(err_str1, get_output(1))
-    @test occursin(err_str2, get_output(2))
-    @test occursin(err_str3_1, get_output(3))
-    @test occursin(err_str3_2, get_output(3))
+    @test occursin(normalize_err(err_str2), normalize_err(get_output(2)))
+    @test occursin(normalize_err(err_str3_1), normalize_err(get_output(3)))
+    @test occursin(normalize_err(err_str3_2), normalize_err(get_output(3)))
 end
 
 # TODO: move this into chunk option tests


### PR DESCRIPTION
## Summary
- In Julia 1.12, `ParseError` messages include source locations and `UndefVarError` messages include module names
- These differ between the test's `include_string(Main, ...)` and Weave's execution context (temp files, sandbox module), causing 3 test failures
- Normalize source locations, module names, and whitespace before comparing error strings

## Test plan
- [x] `Pkg.test()` passes: 194 passed, 2 broken (pre-existing), 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)