### PR TITLE
Add run_path to control execution directory independently of output

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 ## Release notes for Weave.jl
 
+### Unreleased
+
+improvements:
+- added `run_path` keyword argument to `weave()` to control the code execution directory independently of the output directory (`out_path`). Supported values are `:doc`, `:pwd`, a path string, or `nothing` (default, preserves previous behavior). Also available as `run_path` in the YAML `weave_options` header.
+
+internal:
+- renamed `WeaveDoc.cwd` field to `out_dir` and `get_cwd` to `get_out_dir`. Backward compatibility for `doc.cwd` is preserved via property overrides.
+
+
 ### v0.10.6 – 2020/10/03
 
 improvements:

--- a/doc/src/header.md
+++ b/doc/src/header.md
@@ -67,6 +67,16 @@ weave_options:
 ---
 ```
 
+You can use `run_path` to control where code is executed independently of `out_path`.
+For example, to output results to a `build` directory while running code from the document's directory:
+```yaml
+---
+weave_options:
+  out_path: build
+  run_path: :doc
+---
+```
+
 !!! note
     - configurations specified within the YAML header have higher precedence than those specified via `weave` keyword arguments
     - chunk options specified within each chunk have higher precedence than the global global chunk options specified within the YAML header

--- a/doc/src/usage.md
+++ b/doc/src/usage.md
@@ -7,6 +7,8 @@ syntax and use [`weave`](@ref) function to execute to document to capture result
 
 Weave document with markup and julia code using `Plots.jl` for plots,
 `out_path = :pwd` makes the results appear in the current working directory.
+Use `run_path` to control where code is executed independently of the output directory,
+e.g. `run_path = :doc` runs code from the source document's directory.
 
 > A prepared example: [`Weave.SAMPLE_JL_DOC`](../examples/FIR_design.jmd)
 

--- a/src/Weave.jl
+++ b/src/Weave.jl
@@ -72,7 +72,7 @@ function tangle(
     informat::Union{Nothing,AbstractString} = nothing,
 )
     doc = WeaveDoc(source, informat)
-    doc.cwd = get_cwd(doc, out_path)
+    doc.out_dir = get_out_dir(doc, out_path)
 
     out_path = get_out_path(doc, out_path, "jl")
 
@@ -101,6 +101,11 @@ Weave an input document to output file.
   * `:doc`: Path of the source document (default)
   * `:pwd`: Julia working directory
   * `"somepath"`: `String` of output directory e.g. `"~/outdir"`, or of filename e.g. `"~/outdir/outfile.tex"`
+- `run_path::Union{Nothing,Symbol,AbstractString} = nothing`: Directory where code is executed. By default (i.e. given `nothing`), code runs in the output directory (same as `out_path`). Can be either of:
+  * `nothing`: Use output directory (default, preserves previous behavior)
+  * `:doc`: Path of the source document
+  * `:pwd`: Julia working directory
+  * `"somepath"`: `String` of directory e.g. `"~/myproject"`
 - `args::Any = Dict()`: A runtime object that is available as `WEAVE_ARGS` while `weave`ing
 - `mod::Union{Module,Nothing} = nothing`: Module where Weave `eval`s code. You can pass a `Module` object, otherwise create an new sandbox module.
 - `fig_path::Union{Nothing,AbstractString} = nothing`: Where figures will be generated, relative to `out_path`. By default (i.e. given `nothing`), Weave will automatically create `$(DEFAULT_FIG_PATH)` directory.
@@ -126,6 +131,7 @@ function weave(
     doctype::Union{Nothing,AbstractString} = nothing,
     informat::Union{Nothing,AbstractString} = nothing,
     out_path::Union{Symbol,AbstractString} = :doc,
+    run_path::Union{Nothing,Symbol,AbstractString} = nothing,
     args::Any = Dict(),
     mod::Union{Module,Nothing} = nothing,
     fig_path::Union{Nothing,AbstractString} = nothing,
@@ -165,6 +171,16 @@ function weave(
                 end
             end
         end
+        if haskey(weave_options, "run_path")
+            run_path = let
+                run_path = weave_options["run_path"]
+                if run_path == ":doc" || run_path == ":pwd"
+                    Symbol(run_path)
+                else
+                    normpath(dirname(source), run_path) # resolve relative to this document
+                end
+            end
+        end
         mod = get(weave_options, "mod", mod)
         mod isa AbstractString && (mod = Main.eval(Meta.parse(mod)))
         fig_path = get(weave_options, "fig_path", fig_path)
@@ -178,6 +194,7 @@ function weave(
         doctype = doctype,
         mod = mod,
         out_path = out_path,
+        run_path = run_path,
         args = args,
         fig_path = fig_path,
         fig_ext = fig_ext,
@@ -245,9 +262,9 @@ end
 get_out_path(doc, out_path, ext::Nothing = nothing) = get_out_path(doc, out_path, doc.format.extension)
 function get_out_path(doc, out_path, ext)
     if (out_path === :doc) || (out_path === :pwd)
-        abspath(get_cwd(doc, out_path), string(doc.basename, '.', ext))
+        abspath(get_out_dir(doc, out_path), string(doc.basename, '.', ext))
     elseif isempty(splitext(out_path)[2]) # directory given
-        abspath(get_cwd(doc, out_path), string(doc.basename, '.', ext))
+        abspath(get_out_dir(doc, out_path), string(doc.basename, '.', ext))
     else
         # out_path is given, but if extension is explitly provided override this will override the extension
         abspath(string(splitext(out_path)[1], '.', ext))
@@ -287,7 +304,7 @@ function notebook(
 )
     doc = WeaveDoc(source)
     converted = convert_to_notebook(doc)
-    doc.cwd = get_cwd(doc, out_path)
+    doc.out_dir = get_out_dir(doc, out_path)
     out_path = get_out_path(doc, out_path, "ipynb")
 
     write(out_path, converted)

--- a/src/cache.jl
+++ b/src/cache.jl
@@ -1,7 +1,7 @@
 # Serialization is imported only if cache is used
 
 function write_cache(doc::WeaveDoc, cache_path)
-    cache_dir = joinpath(doc.cwd, cache_path)
+    cache_dir = joinpath(doc.out_dir, cache_path)
     isdir(cache_dir) || mkpath(cache_dir)
     open(joinpath(cache_dir, doc.basename * ".cache"), "w") do io
         Serialization.serialize(io, doc)
@@ -10,7 +10,7 @@ function write_cache(doc::WeaveDoc, cache_path)
 end
 
 function read_cache(doc::WeaveDoc, cache_path)
-    name = joinpath(doc.cwd, cache_path, doc.basename * ".cache")
+    name = joinpath(doc.out_dir, cache_path, doc.basename * ".cache")
     isfile(name) || return nothing
     open(name, "r") do io
         doc = Serialization.deserialize(io)

--- a/src/reader/reader.jl
+++ b/src/reader/reader.jl
@@ -33,6 +33,7 @@ function WeaveDoc(source, informat = nothing)
         path,
         chunks,
         "",
+        "",
         nothing,
         "",
         "",

--- a/src/run.jl
+++ b/src/run.jl
@@ -7,6 +7,7 @@ function run_doc(
     doc::WeaveDoc;
     doctype::Union{Nothing,AbstractString} = nothing,
     out_path::Union{Symbol,AbstractString} = :doc,
+    run_path::Union{Nothing,Symbol,AbstractString} = nothing,
     args::Any = Dict(),
     mod::Union{Module,Nothing} = nothing,
     fig_path::Union{Nothing,AbstractString} = nothing,
@@ -19,18 +20,19 @@ function run_doc(
     doc.doctype = isnothing(doctype) ? (doctype = detect_doctype(doc.source)) : doctype
     doc.format = deepcopy(get_format(doctype))
 
-    cwd = doc.cwd = get_cwd(doc, out_path)
-    mkpath(cwd)
+    out_dir = doc.out_dir = get_out_dir(doc, out_path)
+    run_dir = doc.run_path = get_run_dir(doc, run_path, out_path)
+    mkpath(out_dir)
 
     # TODO: provide a way not to create `fig_path` ?
     if isnothing(fig_path)
         fig_path = if (endswith(doctype, "2pdf") && cache === :off) || endswith(doctype, "2html")
-            basename(mktempdir(abspath(cwd)))
+            basename(mktempdir(abspath(out_dir)))
         else
             DEFAULT_FIG_PATH
         end
     end
-    mkpath(normpath(cwd, fig_path))
+    mkpath(normpath(out_dir, fig_path))
     # This is needed for latex and should work on all output formats
     @static Sys.iswindows() && (fig_path = replace(fig_path, "\\" => "/"))
     set_rc_params(doc, fig_path, fig_ext)
@@ -43,9 +45,9 @@ function run_doc(
 
     mimetypes = doc.format.mimetypes
 
-    report = Report(cwd, doc.basename, doc.format, mimetypes)
+    report = Report(out_dir, doc.basename, doc.format, mimetypes)
     cd_back = let d = pwd(); () -> cd(d); end
-    cd(cwd)
+    cd(run_dir)
     pushdisplay(report)
     try
         if cache !== :off && cache !== :refresh
@@ -91,7 +93,7 @@ function run_doc(
         cd_back()
         popdisplay(report) # ensure display pops out even if internal error occurs
         # Temporary fig_path is not automatically removed because it contains files so...
-        !isnothing(fig_path) && startswith(fig_path, "jl_") && rm(normpath(cwd, fig_path), force=true, recursive=true)
+        !isnothing(fig_path) && startswith(fig_path, "jl_") && rm(normpath(out_dir, fig_path), force=true, recursive=true)
     end
 
     return doc
@@ -116,7 +118,7 @@ function detect_doctype(path)
     return "pandoc"
 end
 
-function get_cwd(doc, out_path)
+function get_out_dir(doc, out_path)
     return if out_path === :doc
         dirname(doc.path)
     elseif out_path === :pwd
@@ -129,6 +131,17 @@ function get_cwd(doc, out_path)
             dirname(path)
         end
     end |> abspath
+end
+
+function get_run_dir(doc, run_path, out_path)
+    isnothing(run_path) && return get_out_dir(doc, out_path)
+    return if run_path === :doc
+        dirname(doc.path)
+    elseif run_path === :pwd
+        pwd()
+    else
+        abspath(run_path)
+    end
 end
 
 function run_chunk(chunk::CodeChunk, doc, report, mod)

--- a/src/types.jl
+++ b/src/types.jl
@@ -9,12 +9,29 @@ mutable struct WeaveDoc
     basename::AbstractString
     path::AbstractString
     chunks::Vector{WeaveChunk}
-    cwd::AbstractString
+    out_dir::AbstractString
+    run_path::AbstractString
     format::Any
     doctype::String
     header_script::String
     header::Dict
     chunk_defaults::Dict{Symbol,Any}
+end
+
+# Backward compatibility: the field was renamed from `cwd` to `out_dir`,
+# but external code may still use `doc.cwd`.
+function Base.getproperty(doc::WeaveDoc, name::Symbol)
+    name === :cwd && return getfield(doc, :out_dir)
+    return getfield(doc, name)
+end
+
+# Backward compatibility: redirect `doc.cwd = ...` to `doc.out_dir = ...`.
+
+function Base.setproperty!(doc::WeaveDoc, name::Symbol, value)
+    name === :cwd && (name = :out_dir)
+    # The convert call replicates what the default setproperty! does,
+    # since our override calls setfield! directly (which does not convert).
+    return setfield!(doc, name, convert(fieldtype(WeaveDoc, name), value))
 end
 
 struct ChunkOutput

--- a/src/writer/latex.jl
+++ b/src/writer/latex.jl
@@ -1,6 +1,6 @@
 function write_doc(docformat::LaTeX2PDF, doc, rendered, out_path)
     cd_back = let d = pwd(); () -> cd(d); end
-    cd(doc.cwd)
+    cd(doc.out_dir)
     try
         tex_path = basename(out_path)
         write(tex_path, rendered)

--- a/test/run/test_run_path.jl
+++ b/test/run/test_run_path.jl
@@ -1,0 +1,60 @@
+@testset "run_path separates execution and output directories" begin
+
+# Create a document that writes a marker file and reads a file from cwd
+doc_body = """
+```julia
+pwd()
+```
+
+```julia
+read("run_path_input.txt", String)
+```
+"""
+
+# Set up: doc in one dir, input file in another
+doc_dir = mktempdir()
+run_dir = mktempdir()
+out_dir = mktempdir()
+
+doc_path = joinpath(doc_dir, "test_run_path.jmd")
+write(doc_path, doc_body)
+write(joinpath(run_dir, "run_path_input.txt"), "hello from run_dir")
+
+@testset "run_path controls execution directory" begin
+    doc = run_doc(WeaveDoc(doc_path); out_path = out_dir, run_path = run_dir)
+    # pwd() during execution should be run_dir
+    @test occursin(run_dir, doc.chunks[1].output)
+    # reading a file relative to cwd should find run_dir's file
+    @test occursin("hello from run_dir", doc.chunks[2].output)
+    # output should go to out_dir
+    @test doc.out_dir == out_dir
+end
+
+@testset "run_path=:doc runs from document directory" begin
+    write(joinpath(doc_dir, "run_path_input.txt"), "hello from doc_dir")
+    doc = run_doc(WeaveDoc(doc_path); out_path = out_dir, run_path = :doc)
+    @test occursin(doc_dir, doc.chunks[1].output)
+    @test occursin("hello from doc_dir", doc.chunks[2].output)
+end
+
+@testset "run_path=nothing preserves default behavior" begin
+    write(joinpath(out_dir, "run_path_input.txt"), "hello from out_dir")
+    doc = run_doc(WeaveDoc(doc_path); out_path = out_dir, run_path = nothing)
+    # default: execution dir == output dir
+    @test occursin(out_dir, doc.chunks[1].output)
+    @test occursin("hello from out_dir", doc.chunks[2].output)
+end
+
+@testset "run_path via weave()" begin
+    write(joinpath(run_dir, "run_path_input.txt"), "hello from run_dir")
+    result_path = weave(doc_path; out_path = out_dir, run_path = run_dir)
+    try
+        body = read(result_path, String)
+        @test occursin(run_dir, body)
+        @test occursin("hello from run_dir", body)
+    finally
+        rm(result_path, force=true)
+    end
+end
+
+end # @testset

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,6 +47,7 @@ end
         include("run/test_module.jl")
         include("run/test_meta.jl")
         include("run/test_error.jl")
+        include("run/test_run_path.jl")
     end
 
     @testset "render" begin


### PR DESCRIPTION
## Summary
- `weave()` previously conflated the code execution directory with the output directory via the single `out_path` parameter
- Add a `run_path` keyword argument that independently controls where code is executed, e.g. `weave("doc.jmd", out_path=:pwd, run_path=:doc)` outputs to the cwd while running code from the document's directory
- Supported values: `nothing` (default, preserves previous behavior), `:doc`, `:pwd`, or a path string
- Also available as `run_path` in the YAML `weave_options` header
- Internal: rename `WeaveDoc.cwd` → `out_dir` and `get_cwd` → `get_out_dir` (backward compat for `doc.cwd` preserved via property overrides)

Depends on #493.

## Test plan
- [x] All existing tests pass (193 passed, 2 broken pre-existing)
- [x] Test `run_path=:doc` with `out_path=:pwd` to verify independent control

🤖 Generated with [Claude Code](https://claude.com/claude-code)